### PR TITLE
Retry connecting to the ES server instead of immediately failing

### DIFF
--- a/src/main/java/org/obiba/es/mica/ESSearchEngineService.java
+++ b/src/main/java/org/obiba/es/mica/ESSearchEngineService.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import net.minidev.json.JSONObject;
+import org.apache.http.ConnectionClosedException;
 import org.apache.http.HttpHost;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
@@ -45,10 +46,15 @@ import co.elastic.clients.transport.rest_client.RestClientTransport;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.ConnectException;
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
@@ -59,6 +65,10 @@ public class ESSearchEngineService implements SearchEngineService {
   private static final String ES_BRANCH = "8.13.x";
 
   private static final String ES_CONFIG_FILE = "elasticsearch.yml";
+
+  private static final int DEFAULT_MAX_RETIRES = 10;
+  private static final int DEFAULT_INITIAL_BACKOFF = 1000; // Miliseconds
+  private static final int DEFAULT_BACKOFF_MULTIPLIER = 2;
 
   private Properties properties;
 
@@ -80,6 +90,8 @@ public class ESSearchEngineService implements SearchEngineService {
 
   private ObjectMapper yamlObjectMapper = new ObjectMapper(new YAMLFactory());
 
+  private final AtomicBoolean stopRetries = new AtomicBoolean(false); // Flag to stop retries
+
   @Override
   public String getName() {
     return "mica-search-es8";
@@ -100,6 +112,14 @@ public class ESSearchEngineService implements SearchEngineService {
     return running;
   }
 
+
+  public ESSearchEngineService() {
+    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+      // Shutdown detected. Stopping Elasticsearch connection retries
+      stopRetries.set(true);
+    }));
+  }
+
   @Override
   public void start() {
     // do init stuff
@@ -111,7 +131,7 @@ public class ESSearchEngineService implements SearchEngineService {
 
       esIndexer = new ESIndexer(this);
       esSearcher = new ESSearcher(this, bufferLimitBytes == null || bufferLimitBytes.isEmpty() ? 250 * 1024 * 1024
-          : Integer.parseInt(bufferLimitBytes));
+        : Integer.parseInt(bufferLimitBytes));
 
       running = true;
     }
@@ -124,7 +144,7 @@ public class ESSearchEngineService implements SearchEngineService {
       try {
         esNode.close();
       } catch (IOException e) {
-        log.error("Failed to close node {}", e);
+        log.error("Failed to close node {}", e.getMessage());
       }
     }
     if (client != null) {
@@ -183,42 +203,97 @@ public class ESSearchEngineService implements SearchEngineService {
   }
 
   int getNbShards() {
-    return Integer.parseInt(properties.getProperty("shards", "5"));
+    return getIntProperty("shards", 5);
   }
 
   int getNbReplicas() {
-    return Integer.parseInt(properties.getProperty("replicas", "1"));
+    return getIntProperty("replicas", 1);
   }
 
   //
   // Private methods
   //
 
-  private void createTransportClient(Settings.Builder builder) {
+  public void createTransportClient(Settings.Builder builder) {
     builder.put("client.transport.sniff", isTransportSniff());
 
-    HttpHost[] httpHosts = getTransportAddresses()
-        .stream()
-        .map(transportAddress -> {
-          int port = 9200;
-          String host = transportAddress;
-          int sepIdx = transportAddress.lastIndexOf(':');
+    List<String> transportAddresses = getTransportAddresses();
+    HttpHost[] httpHosts = transportAddresses.stream()
+      .map(transportAddress -> {
+        int port = 9200;
+        String host = transportAddress;
+        int sepIdx = transportAddress.lastIndexOf(':');
 
-          if (sepIdx > 0) {
-            port = Integer.parseInt(transportAddress.substring(sepIdx + 1, transportAddress.length()));
-            host = transportAddress.substring(0, sepIdx);
+        if (sepIdx > 0) {
+          port = Integer.parseInt(transportAddress.substring(sepIdx + 1));
+          host = transportAddress.substring(0, sepIdx);
+        }
+
+        return new HttpHost(host, port, "http");
+      })
+      .toArray(HttpHost[]::new);
+
+    int maxRetries = getIntProperty("maxRetries", DEFAULT_MAX_RETIRES);
+    long initialBackoffMs = getIntProperty("initialBackoff", DEFAULT_INITIAL_BACKOFF);
+    int backoffMultiplier = getIntProperty("backoffMultiplier", DEFAULT_BACKOFF_MULTIPLIER);
+
+    // Make sure you do not block the app
+    Thread.ofVirtual().start(() -> retryConnection(httpHosts, maxRetries, initialBackoffMs, backoffMultiplier));
+  }
+
+  private void retryConnection(HttpHost[] httpHosts, int maxRetries, long initialBackoffMs, int backoffMultiplier) {
+    try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      executor.submit(() -> {
+        int attempt = 0;
+        long backoff = initialBackoffMs;
+
+        while (attempt < maxRetries && !stopRetries.get()) {
+          try {
+            RestClient restClient = RestClient.builder(httpHosts).build();
+            RestClientTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
+            client = new ElasticsearchClient(transport);
+
+            if (client.ping().value()) {
+              log.info("Connected to Elasticsearch successfully!");
+              return;
+            }
+
+            throw new IOException("Ping failed - Elasticsearch might not be ready");
+
+          } catch (IOException e) {
+            attempt++;
+            log.warn("Attempt {}/{} failed: {}", attempt, maxRetries, e.getMessage());
+
+            if (!isRetryableException(e)) {
+              log.error("Non-retryable error detected, stopping connection attempts.", e);
+              break;
+            }
+
+            if (attempt < maxRetries && !stopRetries.get()) {
+              try {
+                long nextDelay = backoff;
+                log.info("Retrying in {}ms...", nextDelay);
+                Thread.sleep(nextDelay);
+                backoff *= backoffMultiplier; // Exponential backoff
+              } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                return;
+              }
+            }
           }
+        }
 
-          return new HttpHost(host, port, "http");
-        })
-        .toArray(HttpHost[]::new);
+        if (stopRetries.get()) {
+          log.info("Retrying stopped due to server shutdown.");
+        } else {
+          log.error("Failed to connect to Elasticsearch after {} attempts.", maxRetries);
+        }
+      });
+    }
+  }
 
-    RestClient restClient = RestClient.builder(httpHosts).build();
-
-    JacksonJsonpMapper jacksonJsonpMapper = new JacksonJsonpMapper();
-    RestClientTransport transport = new RestClientTransport(restClient, jacksonJsonpMapper);
-
-    client = new ElasticsearchClient(transport);
+  private boolean isRetryableException(IOException e) {
+    return e instanceof ConnectException || e instanceof UnknownHostException || e instanceof ConnectionClosedException;
   }
 
   private boolean isDataNode() {
@@ -232,7 +307,7 @@ public class ESSearchEngineService implements SearchEngineService {
   private List<String> getTransportAddresses() {
     String addStr = properties.getProperty("transportAddresses", "").trim();
     return addStr.isEmpty() ? Lists.newArrayList("localhost:9200")
-        : Stream.of(addStr.split(",")).map(String::trim).collect(toList());
+      : Stream.of(addStr.split(",")).map(String::trim).collect(toList());
   }
 
   private boolean isTransportClient() {
@@ -267,9 +342,9 @@ public class ESSearchEngineService implements SearchEngineService {
   private Settings.Builder getSettings() {
     File pluginWorkDir = new File(getWorkFolder(), properties.getProperty("es.version", ES_BRANCH));
     Settings.Builder builder = Settings.builder() //
-        .put("path.home", getInstallFolder().getAbsolutePath()) //
-        .put("path.data", new File(pluginWorkDir, "data").getAbsolutePath()) //
-        .put("path.work", new File(pluginWorkDir, "work").getAbsolutePath());
+      .put("path.home", getInstallFolder().getAbsolutePath()) //
+      .put("path.data", new File(pluginWorkDir, "data").getAbsolutePath()) //
+      .put("path.work", new File(pluginWorkDir, "work").getAbsolutePath());
 
     File defaultSettings = new File(getInstallFolder(), ES_CONFIG_FILE);
     if (defaultSettings.exists()) {
@@ -277,8 +352,8 @@ public class ESSearchEngineService implements SearchEngineService {
         builder.loadFromPath(defaultSettings.toPath());
 
         Map<String, Object> defaultSettingsMap = yamlObjectMapper.readValue(defaultSettings,
-            new TypeReference<Map<String, Object>>() {
-            });
+          new TypeReference<Map<String, Object>>() {
+          });
 
         if (defaultSettingsMap.containsKey("index")) {
           Object defaultSettingsIndexObject = defaultSettingsMap.get("index");
@@ -301,5 +376,14 @@ public class ESSearchEngineService implements SearchEngineService {
     builder.put("cluster.name", getClusterName());
 
     return builder;
+  }
+
+  private int getIntProperty(String key, int defaultValue) {
+    try {
+      return Integer.parseInt(properties.getProperty(key, String.valueOf(defaultValue)));
+    } catch (NumberFormatException e) {
+      log.warn("Invalid value for '{}', using default: {}", key, defaultValue);
+      return defaultValue;
+    }
   }
 }


### PR DESCRIPTION
- Tries a predefined # of times to connect to ES server without blocking the app. 
- The `maxRetries`, `initialBackoffMs` and  `backoffMultiplier` can customized in the `site.properties` file. 
- Stops trying to connect upon app shutdown