### PR TITLE
Extract host info at each reconnection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <groupId>org.obiba.es</groupId>
   <artifactId>mica-search-es8</artifactId>
   <packaging>jar</packaging>
-  <version>2.0-SNAPSHOT</version>
+  <version>2.0.1</version>
   <name>mica-search-es8</name>
   <url>http://obiba.org</url>
 
@@ -429,7 +429,7 @@
     <connection>scm:git:https://github.com/obiba/mica-search-es8.git</connection>
     <developerConnection>scm:git:https://github.com/obiba/mica-search-es8.git</developerConnection>
     <url>https://github.com/obiba/mica-search-es8</url>
-    <tag>mica-search-es8-1.0.x</tag>
+    <tag>2.0.1</tag>
   </scm>
 
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <groupId>org.obiba.es</groupId>
   <artifactId>mica-search-es8</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.1</version>
+  <version>2.0-SNAPSHOT</version>
   <name>mica-search-es8</name>
   <url>http://obiba.org</url>
 
@@ -429,7 +429,7 @@
     <connection>scm:git:https://github.com/obiba/mica-search-es8.git</connection>
     <developerConnection>scm:git:https://github.com/obiba/mica-search-es8.git</developerConnection>
     <url>https://github.com/obiba/mica-search-es8</url>
-    <tag>2.0.1</tag>
+    <tag>mica-search-es8-1.0.x</tag>
   </scm>
 
   <issueManagement>


### PR DESCRIPTION
The fix is primarily for `docker-mica` where `site.properties` is edited after the plugin is unzipped and host name changed. This fix picks the correct host name  instead of `localhost`.