### PR TITLE
Bugfix/connection failure

### DIFF
--- a/src/main/java/org/obiba/es/mica/ESSearchEngineService.java
+++ b/src/main/java/org/obiba/es/mica/ESSearchEngineService.java
@@ -247,6 +247,8 @@ public class ESSearchEngineService implements SearchEngineService {
     try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
       executor.submit(() -> {
         HttpHost[] httpHosts = getHttpHosts();
+        log.info("Elasticsearch hosts: {}", Arrays.toString(httpHosts));
+
         int attempt = 0;
         long backoff = initialBackoffMs;
 


### PR DESCRIPTION
The timing issue was due to the time difference between updating the `site.properties` and passing the settings to the plugin service - not always in the proper order. 

Added a fallback host based on the ENV variable `ELASTICSEARCH_HOST` used in the context of Mica as a docker container. 

Worst case, there will be [localhost:9200, localhost:9300, $ELASTICSEARCH_HOST:9200, $ELASTICSEARCH_HOST:9300] hosts to try.